### PR TITLE
Fix isActive check in probe history map

### DIFF
--- a/internal/store/probehistory.go
+++ b/internal/store/probehistory.go
@@ -102,8 +102,8 @@ func (hs probeHistoryMap) Append(source *api.URL, r api.Record) {
 
 // isActive returns if is the specified target active in current execution or not.
 func (hs probeHistoryMap) isActive(target *api.URL) bool {
-        if ph, ok := hs[target.String()]; ok {
-                return ph.isActive()
-        }
-        return false
+	if ph, ok := hs[target.String()]; ok {
+		return ph.isActive()
+	}
+	return false
 }

--- a/internal/store/probehistory.go
+++ b/internal/store/probehistory.go
@@ -102,5 +102,8 @@ func (hs probeHistoryMap) Append(source *api.URL, r api.Record) {
 
 // isActive returns if is the specified target active in current execution or not.
 func (hs probeHistoryMap) isActive(target *api.URL) bool {
-	return hs[target.String()].isActive()
+        if ph, ok := hs[target.String()]; ok {
+                return ph.isActive()
+        }
+        return false
 }

--- a/internal/store/probehistory_internal_test.go
+++ b/internal/store/probehistory_internal_test.go
@@ -125,18 +125,18 @@ func TestProbeHistoryMap(t *testing.T) {
 }
 
 func TestProbeHistoryMap_isActive(t *testing.T) {
-        m := make(probeHistoryMap)
-        target := &api.URL{Scheme: "dummy", Fragment: "is-active-test"}
+	m := make(probeHistoryMap)
+	target := &api.URL{Scheme: "dummy", Fragment: "is-active-test"}
 
-        if m.isActive(target) {
-                t.Fatalf("unexpected active on empty map")
-        }
+	if m.isActive(target) {
+		t.Fatalf("unexpected active on empty map")
+	}
 
-        m.Append(target, api.Record{Time: time.Now(), Target: target})
+	m.Append(target, api.Record{Time: time.Now(), Target: target})
 
-        if !m.isActive(target) {
-                t.Fatalf("expected active after append")
-        }
+	if !m.isActive(target) {
+		t.Fatalf("expected active after append")
+	}
 }
 
 func BenchmarkProbeHistory_sources(b *testing.B) {

--- a/internal/store/probehistory_internal_test.go
+++ b/internal/store/probehistory_internal_test.go
@@ -124,6 +124,21 @@ func TestProbeHistoryMap(t *testing.T) {
 	}
 }
 
+func TestProbeHistoryMap_isActive(t *testing.T) {
+        m := make(probeHistoryMap)
+        target := &api.URL{Scheme: "dummy", Fragment: "is-active-test"}
+
+        if m.isActive(target) {
+                t.Fatalf("unexpected active on empty map")
+        }
+
+        m.Append(target, api.Record{Time: time.Now(), Target: target})
+
+        if !m.isActive(target) {
+                t.Fatalf("expected active after append")
+        }
+}
+
 func BenchmarkProbeHistory_sources(b *testing.B) {
 	for _, n := range []int{1, 10, 100, 1000} {
 		b.Run(fmt.Sprint(n), func(b *testing.B) {


### PR DESCRIPTION
## Summary
- avoid panic when checking if a target history is active
- add unit test covering missing target case

## Testing
- `go test ./internal/store -run ProbeHistoryMap_isActive -count=1`

---

PR made by Codex