### PR TITLE
Fix XLSX TTY check

### DIFF
--- a/cmd/ayd/conv.go
+++ b/cmd/ayd/conv.go
@@ -40,6 +40,16 @@ Options:
   -h, --help    Show this help message and exit.
 `
 
+var (
+	// isTerminal returns whether the given file descriptor is a terminal.
+	// This function can be overridden in tests.
+	isTerminal = isatty.IsTerminal
+
+	// isCygwinTerminal returns whether the given file descriptor is a Cygwin terminal.
+	// This function can be overridden in tests.
+	isCygwinTerminal = isatty.IsCygwinTerminal
+)
+
 func (c ConvCommand) Run(args []string) int {
 	flags := pflag.NewFlagSet("ayd conv", pflag.ContinueOnError)
 
@@ -109,7 +119,7 @@ func (c ConvCommand) Run(args []string) int {
 		}
 		defer f.Close()
 		output = f
-	} else if *toXlsx && isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()) {
+	} else if *toXlsx && (isTerminal(os.Stdout.Fd()) || isCygwinTerminal(os.Stdout.Fd())) {
 		fmt.Fprintln(c.ErrStream, "error: can not write xlsx format to stdout. please redirect or use -o option.")
 		return 2
 	}

--- a/cmd/ayd/conv_internal_test.go
+++ b/cmd/ayd/conv_internal_test.go
@@ -1,11 +1,79 @@
 package main
 
 import (
+	"bytes"
+	"strings"
+	"testing"
 	"time"
+
+	"github.com/macrat/ayd/internal/testutil"
+	"github.com/mattn/go-isatty"
 )
 
 func init() {
 	CurrentTime = func() time.Time {
 		return time.Date(2001, 2, 3, 16, 5, 6, 0, time.UTC)
+	}
+}
+
+func TestConvCommand_TTYWarning(t *testing.T) {
+	formats := []struct {
+		name       string
+		args       []string
+		expectWarn bool
+	}{
+		{"csv_default", []string{}, false},
+		{"csv", []string{"-c"}, false},
+		{"json", []string{"-j"}, false},
+		{"ltsv", []string{"-l"}, false},
+		{"xlsx", []string{"-x"}, true},
+	}
+
+	combos := []struct {
+		name string
+		term bool
+		cyg  bool
+	}{
+		{"no_tty", false, false},
+		{"tty", true, false},
+		{"cygwin", false, true},
+		{"tty_cygwin", true, true},
+	}
+
+	for _, cmb := range combos {
+		for _, f := range formats {
+			name := cmb.name + "/" + f.name
+			t.Run(name, func(t *testing.T) {
+				isTerminal = func(uintptr) bool { return cmb.term }
+				isCygwinTerminal = func(uintptr) bool { return cmb.cyg }
+				defer func() {
+					isTerminal = isatty.IsTerminal
+					isCygwinTerminal = isatty.IsCygwinTerminal
+				}()
+
+				stdout := bytes.NewBuffer(nil)
+				stderr := bytes.NewBuffer(nil)
+				cmd := ConvCommand{strings.NewReader(testutil.DummyLog), stdout, stderr}
+
+				code := cmd.Run(append([]string{"ayd", "conv"}, f.args...))
+
+				warn := strings.Contains(stderr.String(), "can not write xlsx format")
+				if f.expectWarn && (cmb.term || cmb.cyg) {
+					if code != 2 {
+						t.Errorf("expect exit 2 but got %d", code)
+					}
+					if !warn {
+						t.Errorf("expected warning, got %s", stderr.String())
+					}
+				} else {
+					if code != 0 {
+						t.Errorf("unexpected exit code %d", code)
+					}
+					if warn {
+						t.Errorf("unexpected warning: %s", stderr.String())
+					}
+				}
+			})
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- move `isTerminal`/`isCygwinTerminal` helpers above `ConvCommand.Run`
- adjust xlsx condition to use them
- consolidate TTY tests into conv_internal_test.go and cover all format/terminal combinations

## Testing
- `go test ./cmd/ayd -run TestConvCommand_TTYWarning -count=1`
- `go test ./cmd/ayd` *(fails: TestAydCommand_Run_permissionDenied)*
